### PR TITLE
MIGRATION  - Adding support to optionally use LMS API instead of Discovery 

### DIFF
--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -335,7 +335,10 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         elif 'card_image_url' in course_info:
             image = course_info['card_image_url']
         else:
-            image = ''
+            try:
+                image = course_info['media']['image']['raw']
+            except (KeyError, TypeError):
+                image = ''
         return {
             'benefit': serializers.BenefitSerializer(benefit).data,
             'contains_verified': is_verified,

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -271,9 +271,19 @@ class BasketLogicMixin:
                 course_data['image_url'] = course['image']['src']
             except (KeyError, TypeError):
                 pass
+            try:
+                course_data['image_url'] = course['card_image_url']
+            except (KeyError, TypeError):
+                pass
+
+            if not course_data['image_url']:
+                try:
+                    course_data['image_url'] = course['media']['image']['raw']
+                except (KeyError, TypeError):
+                    pass
 
             course_data['product_description'] = course.get('short_description', '')
-            course_data['product_title'] = course.get('title', '')
+            course_data['product_title'] = course.get('name', course.get('title',''))
 
             # The course start/end dates are not currently used
             # in the default basket templates, but we are adding


### PR DESCRIPTION
**Description:**
This PR solves the issue when it's not possible to get course card info from Discovery API

**Related work:**
[Changes](https://github.com/proversity-org/ecommerce/commit/f15bee5ffb8a16afe74259dc7fa1edd7ef426f57)