### PR TITLE
Adding github workflows for labeler deployment and assign by path

### DIFF
--- a/.github/workflows/assign_by_path.yml
+++ b/.github/workflows/assign_by_path.yml
@@ -1,0 +1,28 @@
+name: assign_by_path
+
+on:
+  pull_request:
+    branches:
+      - 'pearson-release/*.master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Assign by path
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - '**/migrations/*'
+      
+      - name: Auto Assign DevOps if exist migrations changes
+        uses: rowi1de/auto-assign-review-teams@v1.0.1
+        if: steps.changes.outputs.src == 'true'
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          teams: "Pearson-Advance/devops"
+          include-draft: false
+          skip-with-manual-reviewers: 4

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,40 @@
+name: ecomm deployment
+
+on:
+  push:
+    branches:
+      - 'pearson-release/*.master'
+      - 'pearson-release/*.dev'
+
+jobs:
+  build-dev:
+    name: Build Dev deployment
+    if: endsWith(github.ref, '.dev')
+    environment: dev
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build jenkins jobs
+      uses: Mondtic/build-jenkins-job@v1.0.0
+      with:
+        jenkins-url: ${{ secrets.JENKINS_URL }}
+        jenkins-token: ${{ secrets.JENKINS_TOKEN }}
+        jenkins-user: ${{ secrets.JENKINS_USER }}
+        jenkins-job: ${{ secrets.JENKINS_JOB }}
+        jenkins-job-params: '{"NODE": "dev", "ENVIRONMENT": "dev", "BRANCH_CUSTOMER_DATA": "development"}'
+        jenkins-wait-job: 'no-wait'
+
+  build-prod:
+    name: Build Prod deployment
+    if: endsWith(github.ref, '.master')
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build jenkins jobs
+      uses: Mondtic/build-jenkins-job@v1.0.0
+      with:
+        jenkins-url: ${{ secrets.JENKINS_URL }}
+        jenkins-token: ${{ secrets.JENKINS_TOKEN }}
+        jenkins-user: ${{ secrets.JENKINS_USER }}
+        jenkins-job: ${{ secrets.JENKINS_JOB }}
+        jenkins-job-params: '{"NODE": "master", "ENVIRONMENT": "prod", "BRANCH_CUSTOMER_DATA": "production"}'
+        jenkins-wait-job: 'no-wait'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: labeler
+
+on:
+  pull_request:
+    branches:
+      - 'pearson-release/*.master'
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: CodelyTV/pr-size-labeler@v1.6.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: '10'
+          s_max_size: '100'
+          m_max_size: '500'
+          l_max_size: '1000'
+          fail_if_xl: 'true'
+          message_if_xl: >
+            'This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.’
+          github_api_url: 'api.github.com'


### PR DESCRIPTION
Added github workflows with the next actions:

1. assign_by_path: assign to the devops team as a reviewer when in the PR exist migrations changes.
2. deployment: make a deployment to dev or production.
3. labeler: set a label with a size name for the PR depending on the number of changes.