### PR TITLE
PAE-344 - Adding support to enable the new course seat name

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -129,6 +129,14 @@ class Course(models.Model):
 
     def get_course_seat_name(self, certificate_type, id_verification_required):
         """ Returns the name for a course seat. """
+        if (getattr(settings, 'ENABLE_CUSTOM_COURSE_SEAT_NAME', False) and
+                getattr(settings, 'CUSTOM_SEAT_NAME', '')):
+            name = u'Seat in {} {} course'.format(
+                getattr(settings, 'CUSTOM_SEAT_NAME'),
+                self.name
+            )
+            return name
+
         name = u'Seat in {}'.format(self.name)
 
         if certificate_type != '':

--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -129,12 +129,12 @@ class Course(models.Model):
 
     def get_course_seat_name(self, certificate_type, id_verification_required):
         """ Returns the name for a course seat. """
-        if (getattr(settings, 'ENABLE_CUSTOM_COURSE_SEAT_NAME', False) and
-                getattr(settings, 'CUSTOM_SEAT_NAME', '')):
-            name = u'Seat in {} {} course'.format(
-                getattr(settings, 'CUSTOM_SEAT_NAME'),
-                self.name
+        if getattr(settings, 'CUSTOM_COURSE_SEAT_NAME', ''):
+            name = 'Seat in {} {} course'.format(
+                getattr(settings, 'CUSTOM_COURSE_SEAT_NAME'),
+                self.name,
             )
+
             return name
 
         name = u'Seat in {}'.format(self.name)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -808,5 +808,4 @@ SDN_CHECK_API_URL ="https://api.trade.gov/gateway/v1/consolidated_screening_list
 SDN_CHECK_API_KEY = "sdn search key here"
 
 # To customize the seat name
-ENABLE_CUSTOM_COURSE_SEAT_NAME = False
-CUSTOM_SEAT_NAME = '' # Seat in {CUSTOM_SEAT_NAME} course
+CUSTOM_COURSE_SEAT_NAME = '' # Seat in {CUSTOM_COURSE_SEAT_NAME} course

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -806,3 +806,7 @@ HUBSPOT_SALES_LEAD_FORM_GUID = "SET-ME-PLEASE"
 # To check government purchase restriction lists
 SDN_CHECK_API_URL ="https://api.trade.gov/gateway/v1/consolidated_screening_list/search"
 SDN_CHECK_API_KEY = "sdn search key here"
+
+# To customize the seat name
+ENABLE_CUSTOM_COURSE_SEAT_NAME = False
+CUSTOM_SEAT_NAME = '' # Seat in {CUSTOM_SEAT_NAME} course

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -120,5 +120,4 @@ CORS_ALLOW_HEADERS = corsheaders_default_headers + (
 )
 
 # To customize the seat name
-ENABLE_CUSTOM_COURSE_SEAT_NAME = config_from_yaml.get('ENABLE_CUSTOM_COURSE_SEAT_NAME', False)
-CUSTOM_SEAT_NAME = config_from_yaml.get('CUSTOM_SEAT_NAME', '')
+CUSTOM_COURSE_SEAT_NAME = config_from_yaml.get('CUSTOM_COURSE_SEAT_NAME', '')

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -118,3 +118,7 @@ ENTERPRISE_CUSTOMERS_EXCLUDED_FROM_CATALOG = config_from_yaml.get('ENTERPRISE_CU
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',
 )
+
+# To customize the seat name
+ENABLE_CUSTOM_COURSE_SEAT_NAME = config_from_yaml.get('ENABLE_CUSTOM_COURSE_SEAT_NAME', False)
+CUSTOM_SEAT_NAME = config_from_yaml.get('CUSTOM_SEAT_NAME', '')


### PR DESCRIPTION
**Description:**
This PR adds the functionality to change the course seat name in in get_course_seat_name by disabling/enabling the variable ENABLE_CUSTOM_COURSE_SEAT_NAME in settings. There is also`CUSTOM_SEAT_NAME` which allows to set the custom name. Let me show the following example:

`Seat in {CUSTOM_SEAT_NAME} <<Course Title>> course`
If `CUSTOM_SEAT_NAME = 'the Pearson Advanced`, then the resulting course seat name will be:
`Seat in the Pearson Advanced <<Course Title>> course`