### PR TITLE
PAE-807 - Allow to get site settings from template tag.

### DIFF
--- a/ecommerce/core/templatetags/core_extras.py
+++ b/ecommerce/core/templatetags/core_extras.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from crum import get_current_request
 from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
@@ -11,11 +12,22 @@ register = template.Library()
 @register.simple_tag
 def settings_value(name):
     """
-    Retrieve a value from settings.
+    Retrieve a value from the site configuration or settings.
+
+    Usage:
+        {% load core_extras %}
+
+        {% settings_value 'site_setting' as setting %}{{ setting }}
+        {% settings_value 'custom_settings' as setting %}{{ setting.my_custom_setting }}
 
     Raises:
         AttributeError if setting not found.
     """
+    request = get_current_request()
+
+    if request.site:
+        return getattr(request.site.siteconfiguration, name)
+
     return getattr(settings, name)
 
 


### PR DESCRIPTION
## Description:

This PR adds a new ability to get settings from site configuration using the "setings_value" template tag. This allows us to get the site settings directly from the HTML templates.

## Usage:

```
{% load core_extras %}

{% settings_value 'site_setting' as setting %}{{ setting }}
{% settings_value 'custom_settings' as setting %}{{ setting.my_custom_setting }}
```

## Reviewers:

- [ ] @diegomillan 
- [ ] @ivanvgh 