### PR TITLE
PAE-344 - Adding support to enable the new course seat name.

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -129,6 +129,11 @@ class Course(models.Model):
 
     def get_course_seat_name(self, certificate_type, id_verification_required):
         """ Returns the name for a course seat. """
+        custom_seat_name = getattr(settings, 'CUSTOM_COURSE_SEAT_NAME', '')
+
+        if custom_seat_name:
+            return 'Seat in {} {} course'.format(custom_seat_name, self.name)
+
         name = u'Seat in {}'.format(self.name)
 
         if certificate_type != '':

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -806,3 +806,6 @@ HUBSPOT_SALES_LEAD_FORM_GUID = "SET-ME-PLEASE"
 # To check government purchase restriction lists
 SDN_CHECK_API_URL ="https://api.trade.gov/gateway/v1/consolidated_screening_list/search"
 SDN_CHECK_API_KEY = "sdn search key here"
+
+# To customize the seat name.
+CUSTOM_COURSE_SEAT_NAME = '' # Seat in {CUSTOM_COURSE_SEAT_NAME} <<Course Title>> course.

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -118,3 +118,6 @@ ENTERPRISE_CUSTOMERS_EXCLUDED_FROM_CATALOG = config_from_yaml.get('ENTERPRISE_CU
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',
 )
+
+# To customize the seat name.
+CUSTOM_COURSE_SEAT_NAME = config_from_yaml.get('CUSTOM_COURSE_SEAT_NAME', '')


### PR DESCRIPTION
**Description:**
This PR adds the functionality to change the course seat name in get_course_seat_name by defining the setting CUSTOM_COURSE_SEAT_NAME. Let me show you the following example:

If CUSTOM_COURSE_SEAT_NAME is defined, then the resulting course seat name will be `Seat in {CUSTOM_COURSE_SEAT_NAME} <<Course Title>> course`. Otherwise, the  normal behavior takes place.


**Ticket**: [PAE-344](https://pearsonadvance.atlassian.net/browse/PAE-344)
