### PR TITLE
PAE-810 - Change email to link for contacting support

### DIFF
--- a/ecommerce/templates/oscar/checkout/cancel_checkout.html
+++ b/ecommerce/templates/oscar/checkout/cancel_checkout.html
@@ -1,7 +1,9 @@
 {% extends 'edx/base.html' %}
+{% load core_extras %}
 {% load i18n %}
 {% load django_markup %}
 {% load static %}
+{% settings_value 'payment_support_url' as support_url %}
 
 {% block title %}
     {% trans "Checkout Cancelled" as tmsg %}{{ tmsg | force_escape }}
@@ -16,11 +18,10 @@
     <h1>{% trans "Checkout Cancelled" as tmsg %}{{ tmsg | force_escape }}</h1>
     <p>
         {% blocktrans asvar tmsg %}
-        Your transaction has been cancelled. If you feel an error has occurred, contact {start_link}
-        {payment_support_email}{end_link}.
+        Your transaction has been cancelled. If you feel an error has occurred, go to {start_link}
+        {support_url}{end_link}.
         {% endblocktrans %}
-        {% interpolate_html tmsg start_link="<a class='nav-link' href='mailto:"|add:payment_support_email|add:"'>"|safe end_link="</a>"|safe payment_support_email=payment_support_email|safe %}
-
+        {% interpolate_html tmsg start_link="<a class='nav-link' href='"|add:support_url|add:"'>"|safe end_link="</a>"|safe support_url=support_url|safe %}
     </p>
 </div>
 {% endblock content %}


### PR DESCRIPTION
## Description:

This PR uses the new feature to get settings from site configuration at template level in order to change the email to the link for contacting support. Therefore, `payment_support_url` must be defined in site configuration.

## Changes:
![image](https://user-images.githubusercontent.com/40271196/129421311-dad6707b-1be8-4bb9-80f7-f27600de7599.png)



