### PR TITLE
PAE-797 - Update enrollment code page behavior for special coupons.

### DIFF
--- a/ecommerce/core/templatetags/core_extras.py
+++ b/ecommerce/core/templatetags/core_extras.py
@@ -10,6 +10,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from ecommerce.extensions.basket.models import Basket
 from ecommerce.extensions.order.models import Order, OrderDiscount
+from ecommerce.extensions.voucher.models import Voucher
 
 register = template.Library()
 
@@ -17,10 +18,10 @@ register = template.Library()
 def get_coupon_name(provided_object):
     """
     The coupon name is extracted from the 'provided_object' argument which could be an
-    Order, Basket or OrderDiscount instance.
+    Order, Basket, OrderDiscount or Voucher instance.
 
     Arguments:
-        provided_object (Order or Basket or OrderDiscount): Order of the purchase,
+        provided_object (Order or Basket or OrderDiscount or Voucher): Order of the purchase,
         its basket or its OrderDiscount.
 
     Returns:
@@ -36,6 +37,8 @@ def get_coupon_name(provided_object):
         coupon_name = coupon.name if coupon else ''
     elif isinstance(provided_object, OrderDiscount):
         coupon_name = provided_object.voucher.name if provided_object.voucher else ''
+    elif isinstance(provided_object, Voucher):
+        coupon_name = provided_object.name
 
     return coupon_name
 

--- a/ecommerce/core/tests/test_templatetags_utils.py
+++ b/ecommerce/core/tests/test_templatetags_utils.py
@@ -5,6 +5,7 @@ from mock import Mock
 from ecommerce.core.templatetags.core_extras import get_coupon_name
 from ecommerce.extensions.basket.models import Basket, BasketAttribute, BasketAttributeType
 from ecommerce.extensions.order.models import Order, OrderDiscount
+from ecommerce.extensions.voucher.models import Voucher
 
 
 @ddt.ddt
@@ -92,6 +93,16 @@ class CoreExtrasUtilsTests(TestCase):
         result = get_coupon_name(order_discount)
 
         self.assertEqual(result, '')
+
+    def test_get_coupon_name_from_voucher(self):
+        """This test checks that 'get_coupon_name' returns the coupon name
+        directly from the voucher."""
+        voucher = Mock(spec=Voucher)
+        voucher.name = 'voucher-name'
+
+        result = get_coupon_name(voucher)
+
+        self.assertEqual(result, 'voucher-name')
 
     @ddt.data(None, 'string', [], {'test-key': 'value'}, BasketAttributeType, BasketAttribute)
     def test_get_coupon_name_called_with_unexpected_argument(self, object_provided):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -135,6 +135,8 @@ class CouponOfferView(TemplateView):
             })
             self.template_name = 'coupons/offer.html'
 
+        context_data['voucher'] = voucher
+
         return context_data
 
     @method_decorator(login_required_for_credit)

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -435,6 +435,8 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             'stockrecords': serializers.StockRecordSerializer(seat.stockrecords.first()).data,
             'title': course.name,
             'voucher_end_date': voucher.end_datetime,
+            'special_coupon': False,
+            'special_coupon_message': '',
         })
 
     def test_get_offers_for_multiple_courses_voucher(self):
@@ -468,6 +470,8 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             'stockrecords': serializers.StockRecordSerializer(seat.stockrecords.first()).data,
             'title': course.name,
             'voucher_end_date': voucher.end_datetime,
+            'special_coupon': False,
+            'special_coupon_message': '',
         })
 
     def test_get_offers_for_enterprise_catalog_voucher(self):
@@ -507,6 +511,8 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             'stockrecords': serializers.StockRecordSerializer(seat.stockrecords.first()).data,
             'title': course.name,
             'voucher_end_date': voucher.end_datetime,
+            'special_coupon': False,
+            'special_coupon_message': '',
         })
 
     def test_get_offers_for_enterprise_offer(self):
@@ -544,6 +550,8 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             'stockrecords': serializers.StockRecordSerializer(seat.stockrecords.first()).data,
             'title': course.name,
             'voucher_end_date': voucher.end_datetime,
+            'special_coupon': False,
+            'special_coupon_message': '',
         })
 
     def test_get_offers_for_enterprise_offer_no_catalog(self):
@@ -602,6 +610,8 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             'stockrecords': serializers.StockRecordSerializer(seat.stockrecords.first()).data,
             'title': course.name,
             'voucher_end_date': voucher.end_datetime,
+            'special_coupon': False,
+            'special_coupon_message': '',
         })
 
     def test_get_course_offer_data(self):
@@ -645,6 +655,8 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             'stockrecords': serializers.StockRecordSerializer(stock_record).data,
             'title': course.name,
             'voucher_end_date': voucher.end_datetime,
+            'special_coupon': False,
+            'special_coupon_message': '',
         })
 
     def test_get_course_offer_verify_null_fields(self):
@@ -719,6 +731,8 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
                 'stockrecords': serializers.StockRecordSerializer(seat.stockrecords.first()).data,
                 'title': course.name,
                 'voucher_end_date': voucher.end_datetime,
+                'special_coupon': False,
+                'special_coupon_message': '',
             }],
         )
 

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -20,6 +20,7 @@ from six.moves.urllib.parse import urlparse
 from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.constants import DEFAULT_CATALOG_PAGE_SIZE
+from ecommerce.core.templatetags.core_extras import get_special_coupon_data, is_special_coupon
 from ecommerce.coupons.utils import fetch_course_catalog, get_catalog_course_runs
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import get_course_info_from_catalog
@@ -98,6 +99,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
                 path=request.path,
                 query=next_page_query,
             )
+
         return Response(data=offers_data)
 
     def retrieve_course_objects(self, results, course_seat_types):
@@ -339,6 +341,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
                 image = course_info['media']['image']['raw']
             except (KeyError, TypeError):
                 image = ''
+
         return {
             'benefit': serializers.BenefitSerializer(benefit).data,
             'contains_verified': is_verified,
@@ -351,5 +354,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             'seat_type': product.attr.certificate_type,
             'stockrecords': serializers.StockRecordSerializer(stock_record).data,
             'title': course_info.get('title', course.name),
-            'voucher_end_date': voucher.end_datetime
+            'voucher_end_date': voucher.end_datetime,
+            'special_coupon': is_special_coupon(voucher),
+            'special_coupon_message': get_special_coupon_data(voucher),
         }

--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -22,15 +22,19 @@
                 <div class="box-shadow col-xs-12">
                     <div class="col-sm-5">
                         <div class="image-container">
+                        <% if (!course.attributes.special_coupon) { %>
                             <div class="discount-percentage"><p><%= course.attributes.benefit_value %>
                                 <span><%- gettext('off') %></span></p>
                             </div>
+                        <% } %>
                             <img class="img-responsive" src="<%= course.attributes.image_url %>"
                                  alt="<%= course.attributes.title %>"/>
 
+                        <% if (!course.attributes.special_coupon) { %>
                             <div class="voucher-valid-until">
                                 <p><%= course.attributes.voucher_end_date_text %></p>
                             </div>
+                        <% } %>
                         </div>
                     </div>
                     <div class="col-sm-7 col-xs-12">
@@ -50,16 +54,24 @@
                                 </p>
                             </div>
                             <% } else { %>
-                            <div class="pull-left">
-                                <p class="course-price">
-                                    <span>$<%= course.attributes.stockrecords.price_excl_tax %></span>
-                                </p>
-                            </div>
-                            <div class="pull-left">
-                                <p class="course-new-price">
-                                    <span><%- gettext('Now') %> $<%= course.attributes.new_price %></span>
-                                </p>
-                            </div>
+                                <% if (course.attributes.special_coupon) { %>
+                                <div class="pull-left">
+                                    <p class="course-new-price">
+                                        <span><%- course.attributes.special_coupon_message %> $<%= course.attributes.new_price %></span>
+                                    </p>
+                                </div>
+                                <% } else { %>
+                                <div class="pull-left">
+                                    <p class="course-price">
+                                        <span>$<%= course.attributes.stockrecords.price_excl_tax %></span>
+                                    </p>
+                                </div>
+                                <div class="pull-left">
+                                    <p class="course-new-price">
+                                        <span><%- gettext('Now') %> $<%= course.attributes.new_price %></span>
+                                    </p>
+                                </div>
+                                <% } %>
                             <% } %>
                             <div class="pull-right">
                                     <% if (isCredit) { %>


### PR DESCRIPTION
## Description:

This PR is intended to update the enrollment code offer page in order to suppress any discount information when using special coupons. This is related to this [PR](https://github.com/Pearson-Advance/ecommerce/pull/26).

To allow to hide the discount messages in `offer.html`, I now pass the `voucher` as context, then use the template tag already created for special coupons (`is_special_coupon`) but first I had to extend its capability to process voucher objects, so `get_coupon_name` was updated.

Inside `offer.html` there is a div, for which its content is rendered with JavaScript, so no django templates here. To pass information in order to suppress the discount messages, I had to update the API that is used by the JavaScript code by passing more variables.

### Note:
The changes for offer.html` are in this [PR](https://github.com/Pearson-Advance/openedx-themes/pull/188)

### Why this PR updates .html files and not handled in themes?
- _offer_course_list.html
As an _file.html within static folder, Our current theming does not take into account those files, and that's why this PR has to change `_offer_course_list.html`.


Changes:

Normal coupon:
![image](https://user-images.githubusercontent.com/40271196/142201068-b04c2ad2-7aab-448f-8a06-c2fb1ac70779.png)

Special Coupon:
![image](https://user-images.githubusercontent.com/40271196/142200967-86c78100-99e0-4bcf-8885-44fa0cd2d0a8.png)





