### PR TITLE
PAE-797.1 - Add a filter and a template tags to check special coupons and get its information.

### DIFF
--- a/ecommerce/core/templatetags/core_extras.py
+++ b/ecommerce/core/templatetags/core_extras.py
@@ -1,12 +1,78 @@
 from __future__ import absolute_import
 
+import re
+
 from crum import get_current_request
 from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
 from opaque_keys.edx.keys import CourseKey
 
+from ecommerce.extensions.basket.models import Basket
+from ecommerce.extensions.order.models import Order, OrderDiscount
+
 register = template.Library()
+
+
+def get_coupon_name(provided_object):
+    """
+    The coupon name is extracted from the 'provided_object' argument which could be an
+    Order, Basket or OrderDiscount instance.
+
+    Arguments:
+        provided_object (Order or Basket or OrderDiscount): Order of the purchase,
+        its basket or its OrderDiscount.
+
+    Returns:
+        str: Coupon name if found, '' otherwise.
+    """
+    coupon_name = ''
+
+    if isinstance(provided_object, Order):
+        discount = provided_object.basket_discounts.first()
+        coupon_name = discount.voucher.name if getattr(discount, 'voucher', None) else ''
+    elif isinstance(provided_object, Basket):
+        coupon = provided_object.vouchers.first()
+        coupon_name = coupon.name if coupon else ''
+    elif isinstance(provided_object, OrderDiscount):
+        coupon_name = provided_object.voucher.name if provided_object.voucher else ''
+
+    return coupon_name
+
+
+def has_request_siteconfiguration(request):
+    """
+    Checks that request has site/siteconfiguration.
+
+    Returns:
+        bool: True if request has site/configuration, False otherwise.
+    """
+    if getattr(request, 'site', None) and getattr(request.site, 'siteconfiguration', None):
+        return True
+
+    return False
+
+
+def is_valid_special_coupon(coupon_name, prefix):
+    """Checks if coupon_name matches the regex of a special coupon.
+    The format depends on the 'prefix' argument.
+
+    regex: r'[{prefix}]\\d.\\d'
+    """
+    def is_valid_prefix(prefix):
+        """The prefix must be a 1-char long string."""
+        if not isinstance(prefix, str):
+            return False
+
+        return len(prefix) == 1
+
+    if not is_valid_prefix(prefix):
+        return False
+
+    return re.match(
+        r'[{prefix}]\d.\d'.format(prefix=prefix),
+        coupon_name,
+    )
 
 
 @register.simple_tag
@@ -29,6 +95,90 @@ def settings_value(name):
         return getattr(request.site.siteconfiguration, name)
 
     return getattr(settings, name)
+
+
+@register.simple_tag(name='is_special_coupon')
+def is_special_coupon(provided_object):
+    """
+    Checks if 'provided_object' contains a coupon which its name meets the format criteria of a special coupon.
+
+    - Requirements: The site.siteconfiguration.custom_settings 'REMOVE_SPECIAL_COUPON_OFFER_PREFIX' key
+    should be set to properly use this tag.
+
+    - Usage: This tag is aimed to be used for conditional logic, as follows.
+        {% load core_extras %}
+
+        {% is_special_coupon order as is_special_coupon %}
+
+        {% if is_special_coupon %}
+                Do something...
+        {% endif %}
+
+    Arguments:
+        provided_object (Order or Basket or OrderDiscount): Order of the purchase,
+        its basket or its OrderDiscount.
+
+    Returns:
+        bool: True if the coupon name is a valid special coupon, False otherwise.
+    """
+    coupon_name = get_coupon_name(provided_object)
+
+    if not coupon_name:
+        return False
+
+    request = get_current_request()
+
+    if not has_request_siteconfiguration(request):
+        return False
+
+    if is_valid_special_coupon(
+            coupon_name,
+            request.site.siteconfiguration.custom_settings.get('REMOVE_SPECIAL_COUPON_OFFER_PREFIX', '')):
+        return True
+
+    return False
+
+
+@register.filter(name='get_special_coupon_data', is_safe=True)
+def get_special_coupon_data(provided_object):
+    """
+    Retrives a custom message for the special coupon.
+
+    Usage: This filter should only be used in conjuction with is_special_coupon tag, as follows.
+        {% load core_extras %}
+
+        {% is_special_coupon order as is_special_coupon %}
+
+        {% if is_special_coupon %}
+                {{ provided_object|get_special_coupon_data }}
+        {% endif %}
+
+    Arguments:
+        provided_object (Order or Basket): Order of the purchase or its basket.
+
+    Returns:
+        str: Special coupon message.
+    """
+    coupon_name = get_coupon_name(provided_object)
+
+    if not coupon_name:
+        return ''
+
+    request = get_current_request()
+
+    if not has_request_siteconfiguration(request):
+        return ''
+
+    if is_valid_special_coupon(
+            coupon_name,
+            request.site.siteconfiguration.custom_settings.get('REMOVE_SPECIAL_COUPON_OFFER_PREFIX', '')):
+        return '{} {}/{}'.format(
+            request.site.siteconfiguration.custom_settings.get('SPECIAL_COUPON_MESSAGE', ''),
+            coupon_name[1],
+            coupon_name[3],
+        )
+
+    return ''
 
 
 @register.tag(name='captureas')

--- a/ecommerce/core/tests/test_templatetags.py
+++ b/ecommerce/core/tests/test_templatetags.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 from crum import set_current_request
 from django.template import Context, Template, TemplateSyntaxError
+from mock import Mock, patch
 
 from ecommerce.tests.testcases import TestCase
 
@@ -45,6 +46,35 @@ class CoreExtrasTests(TestCase):
 
         # If setting is found, tag simply displays setting value.
         self.assertEqual(template.render(Context()), "edX")
+
+    @patch('ecommerce.core.templatetags.core_extras.is_valid_special_coupon')
+    @patch('ecommerce.core.templatetags.core_extras.has_request_siteconfiguration')
+    @patch('ecommerce.core.templatetags.core_extras.get_coupon_name')
+    def test_is_special_coupon_for_order(
+            self, coupon_name_mock, siteconf_mock, is_valid_special_coupon_mock):
+        coupon_name_mock.return_value = '$valid-special-coupon-name'
+        siteconf_mock.return_value = True
+        is_valid_special_coupon_mock.return_value = True
+        setattr(self.request.site.siteconfiguration, 'custom_settings', {'REMOVE_SPECIAL_COUPON_OFFER_PREFIX': '$'})
+        set_current_request(self.request)
+        order = Mock()
+        template = Template(
+            "{% load core_extras %}"
+            "{% is_special_coupon order as is_special_coupon %}"
+            "{{ is_special_coupon }}"
+        )
+
+        self.assertEqual(template.render(Context({'order': order})), "True")
+        coupon_name_mock.assert_called_once_with(order)
+
+        siteconf_mock.return_value = False
+
+        self.assertEqual(template.render(Context({'order': order})), "False")
+
+        coupon_name_mock.return_value = ''
+        siteconf_mock.return_value = True
+
+        self.assertEqual(template.render(Context({'order': order})), "False")
 
     def assertTextCaptured(self, expected):
         template = Template(

--- a/ecommerce/core/tests/test_templatetags_utils.py
+++ b/ecommerce/core/tests/test_templatetags_utils.py
@@ -1,0 +1,102 @@
+import ddt
+from django.test import TestCase
+from mock import Mock
+
+from ecommerce.core.templatetags.core_extras import get_coupon_name
+from ecommerce.extensions.basket.models import Basket, BasketAttribute, BasketAttributeType
+from ecommerce.extensions.order.models import Order, OrderDiscount
+
+
+@ddt.ddt
+class CoreExtrasUtilsTests(TestCase):
+    """Test class for utils implemented in templatetags."""
+
+    def test_get_coupon_name_from_order(self):
+        """This test checks that 'get_coupon_name' returns the coupon name from an
+        Order object if the order has discounts."""
+        coupon_name = 'coupon-name'
+        voucher = Mock()
+        voucher.name = coupon_name
+        discount = Mock(voucher=voucher)
+        order = Mock(spec=Order)
+        order.basket_discounts.first.return_value = discount
+
+        result = get_coupon_name(order)
+
+        self.assertEqual(result, coupon_name)
+
+    def test_get_coupon_name_from_order_without_voucher(self):
+        """This test checks that 'get_coupon_name' returns an empty string
+        if the order has no discounts, and therefore no voucher."""
+        order = Mock(spec=Order)
+        order.basket_discounts.first.return_value = None
+
+        result = get_coupon_name(order)
+
+        self.assertEqual(result, '')
+
+    def test_get_coupon_name_from_basket(self):
+        """This test checks that 'get_coupon_name' returns the coupon name from a
+        Basket object if the basket has a voucher."""
+        coupon_name = 'coupon-name'
+        voucher = Mock()
+        voucher.name = coupon_name
+        basket = Mock(spec=Basket)
+        basket.vouchers.first.return_value = voucher
+
+        result = get_coupon_name(basket)
+
+        self.assertEqual(result, coupon_name)
+
+    def test_get_coupon_name_from_order_with_program_offer(self):
+        """This test checks that 'get_coupon_name' returns an empty string
+        if the order has a program offer discount, which means that the order
+        has a discount but this type of discount has no voucher."""
+        order = Mock(spec=Order)
+        order_discount = Mock(spec=OrderDiscount)
+        order_discount.voucher = None
+        order.basket_discounts.first.return_value = order_discount
+
+        result = get_coupon_name(order)
+
+        self.assertEqual(result, '')
+
+    def test_get_coupon_name_from_basket_without_voucher(self):
+        """This test checks that 'get_coupon_name' returns an empty string
+        if the basket has no voucher."""
+        basket = Mock(spec=Basket)
+        basket.vouchers.first.return_value = None
+
+        result = get_coupon_name(basket)
+
+        self.assertEqual(result, '')
+
+    def test_get_coupon_name_from_orderdiscount(self):
+        """This test checks that 'get_coupon_name' returns the coupon name from a
+        OrderDiscount object if the object has a voucher."""
+        coupon_name = 'coupon-name'
+        order_discount = Mock(spec=OrderDiscount)
+        order_discount.voucher.name = coupon_name
+
+        result = get_coupon_name(order_discount)
+
+        self.assertEqual(result, coupon_name)
+
+    def test_get_coupon_name_from_orderdiscount_with_program_offer(self):
+        """This test checks that 'get_coupon_name' returns an empty string
+        if the order discount comes from a program offer, which means that the order
+        has a discount but this type of discount has no voucher."""
+        order_discount = Mock(spec=OrderDiscount)
+        order_discount.voucher = None
+
+        result = get_coupon_name(order_discount)
+
+        self.assertEqual(result, '')
+
+    @ddt.data(None, 'string', [], {'test-key': 'value'}, BasketAttributeType, BasketAttribute)
+    def test_get_coupon_name_called_with_unexpected_argument(self, object_provided):
+        """This test makes sure that 'get_coupon_name' returns an empty string when called with
+        an argument which is none of these: 'OrderDiscount', 'Basket', or 'Order'."""
+        result = get_coupon_name(object_provided)
+
+        self.assertEqual(result, '')


### PR DESCRIPTION
## Description:
 This PR is intended to cooperate with [This themes PR ](https://github.com/Pearson-Advance/openedx-themes/pull/184). The primary purpose of this PR is to add filter tags in order to validate the format used for special coupons. The filter tags are:

- is_special_coupon
Checks if the coupon name matches the format of a special coupon. Regex format `r'[{prefix}]\d.\d'`, where `{prefix}` should be character, for instance `£`. 
The prefix is configured in custom_settings (Found in eCommerce site configuration) as {"REMOVE_SPECIAL_COUPON_OFFER_PREFIX":"£"}

- get_special_coupon_data
This filter can be used to display a custom message and the number of the special coupon applied. A returned message is `{message} 1/2` where {message} is configured in custom_settings as `{"SPECIAL_COUPON_MESSAGE":"custom message"}`. The `1/2` comes from the coupon name, so this information must be specified while creating the coupon.

## Approach Issue:
I have also added a change in ecommerce/extensions/api/v2/views/coupons.py which addresses the following issue:

When you edit the coupon in ecomm_site/coupons a function is called to also edit the vouchers of the coupon. But when calling `update_voucher_data` its data argument is passed with a dictionary with `{'title':'coupon name'}` but the updatable fields are : `UPDATEABLE_VOUCHER_FIELDS = ['end_datetime', 'start_datetime', 'name']`, so since `'title' != 'name'`, the voucher don't get updated with the name.
