### PR TITLE
PADV 325 - Integrate the build process with ecommerce.

### DIFF
--- a/.github/workflows/build-push-image-main.yml
+++ b/.github/workflows/build-push-image-main.yml
@@ -1,0 +1,30 @@
+name: Tutor Build Action Test
+
+on:
+  push:
+    branches:
+      - 'pearson-release/olive.main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current time
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DD-HH-mm
+      - name: Build Image
+        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        with:
+          python-version: ${{ vars.BUILD_PYTHON_VERSION }}
+          tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
+          path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
+          repository-name: ${{ vars.BUILD_MAIN_REPOSITORY_NAME }}
+          image-name: ${{ vars.BUILD_MAIN_IMAGE_NAME }}
+          image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-${{ steps.current-time.outputs.formattedTime }}
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
+          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-names: '("ecommerce" "discovery" "mfe")'

--- a/.github/workflows/build-push-image-stage.yml
+++ b/.github/workflows/build-push-image-stage.yml
@@ -1,0 +1,30 @@
+name: Tutor Build Action Test
+
+on:
+  push:
+    branches:
+      - 'pearson-release/olive.stage'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current time
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DD-HH-mm
+      - name: Build Image
+        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        with:
+          python-version: ${{ vars.BUILD_PYTHON_VERSION }}
+          tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
+          path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
+          repository-name: ${{ vars.BUILD_STAGE_REPOSITORY_NAME }}
+          image-name: ${{ vars.BUILD_STAGE_IMAGE_NAME }}
+          image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-RC-${{ steps.current-time.outputs.formattedTime }}
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
+          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-names: '("ecommerce" "discovery" "mfe")'


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-325

## Description

This PR aims to add the workflow for automatically building the ecommerce tutor image.

## Type of Change

- [x] Add a new workflow for image building
- [x] Including the tutor-image-building-action action in the workflow
- [x] Trigger workflow on merge with main branches

## How to test

- Create a test PR in the ecommerce repository.
- Merge this PR into the target branch.
- Check that the Github Action is triggered by the PR merge event.
- Check the output of the image build creation for any issues or silent issues.
-  When the process is complete, check the Docker Hub Pearson repository and verify that the image has been built (https://hub.docker.com/repository/docker/pearsonopenedxops/tutor-ecommerce-test/general).
-  Use the image in a local environment to test it out.
- You can use this repo https://github.com/Pearson-Advance/ecommerce/tree/vue/PADV-325.tests to perform any tests

## Reviewers

- [ ] @Squirrel18
- [ ] @sergivalero20
- [ ] @anfbermudezme 