### PR TITLE
PADV-377 - Update inputs in build and push workflows

### DIFF
--- a/.github/workflows/build-push-image-main.yml
+++ b/.github/workflows/build-push-image-main.yml
@@ -6,7 +6,7 @@ on:
       - 'pearson-release/olive.main'
 
 jobs:
-  docker:
+  Build:
     runs-on: ubuntu-latest
     steps:
       - name: Get current time
@@ -20,11 +20,13 @@ jobs:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
           path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
-          repository-name: ${{ vars.BUILD_MAIN_REPOSITORY_NAME }}
-          image-name: ${{ vars.BUILD_MAIN_IMAGE_NAME }}
+          organization-name: ${{ vars.BUILD_ORGANIZATION_NAME }}
+          repository-name: ${{ vars.BUILD_REPOSITORY_NAME }}
           image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-${{ steps.current-time.outputs.formattedTime }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
-          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-sources: '("git+https://github.com/Pearson-Advance/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
           tutor-plugin-names: '("ecommerce" "discovery" "mfe")'
+          tutor-pearson-plugin-url: ${{ vars.TUTOR_PEARSON_PLUGIN_URL }}
+          tutor-pearson-plugin-name: 'pearson-plugin-ecommerce-prod'

--- a/.github/workflows/build-push-image-stage.yml
+++ b/.github/workflows/build-push-image-stage.yml
@@ -6,7 +6,7 @@ on:
       - 'pearson-release/olive.stage'
 
 jobs:
-  docker:
+  Build:
     runs-on: ubuntu-latest
     steps:
       - name: Get current time
@@ -20,11 +20,13 @@ jobs:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
           path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
-          repository-name: ${{ vars.BUILD_STAGE_REPOSITORY_NAME }}
-          image-name: ${{ vars.BUILD_STAGE_IMAGE_NAME }}
+          organization-name: ${{ vars.BUILD_ORGANIZATION_NAME }}
+          repository-name: ${{ vars.BUILD_REPOSITORY_NAME }}
           image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-RC-${{ steps.current-time.outputs.formattedTime }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
-          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-sources: '("git+https://github.com/Pearson-Advance/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
           tutor-plugin-names: '("ecommerce" "discovery" "mfe")'
+          tutor-pearson-plugin-url: ${{ vars.TUTOR_PEARSON_PLUGIN_URL }}
+          tutor-pearson-plugin-name: 'pearson-plugin-ecommerce-stg'


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-377

## Description

This PR changes some inputs as [tutor-build-image-action](https://github.com/Pearson-Advance/tutor-build-image-action/tree/vue/PADV-377) updated the names of its parameters.

## Type of Change

- [x] Change and add new input in workflow for prod.
- [x] Change and add new input in workflow for stage.

## How to test

- Create a test PR in the discovery repository.
- Merge this PR into the target branch.
- Check that the Github Action is triggered by the PR merge event.
- Check the output of the image build creation for any issues or silent issues.
-  When the process is complete, check the Docker Hub Pearson repository and verify that the image has been built (https://hub.docker.com/repository/docker/paops/ecommerce/general).
-  Use the image in a local environment to test it out.

## Reviewers

- [x] @Squirrel18
- [x] @anfbermudezme 
- [x] @alexjmpb  
