### PR TITLE
PADV-377.1 - Change composite action version in workflows to build and push images

### DIFF
--- a/.github/workflows/build-push-image-main.yml
+++ b/.github/workflows/build-push-image-main.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           format: YYYY-MM-DD-HH-mm
       - name: Build Image
-        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        uses: Pearson-Advance/tutor-build-image-action@v1.0.0
         with:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}

--- a/.github/workflows/build-push-image-main.yml
+++ b/.github/workflows/build-push-image-main.yml
@@ -1,0 +1,30 @@
+name: Tutor Build Action Test
+
+on:
+  push:
+    branches:
+      - 'pearson-release/olive.main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current time
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DD-HH-mm
+      - name: Build Image
+        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        with:
+          python-version: ${{ vars.BUILD_PYTHON_VERSION }}
+          tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
+          path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
+          repository-name: ${{ vars.BUILD_MAIN_REPOSITORY_NAME }}
+          image-name: ${{ vars.BUILD_MAIN_IMAGE_NAME }}
+          image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-${{ steps.current-time.outputs.formattedTime }}
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
+          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-names: '("ecommerce" "discovery" "mfe")'

--- a/.github/workflows/build-push-image-main.yml
+++ b/.github/workflows/build-push-image-main.yml
@@ -6,7 +6,7 @@ on:
       - 'pearson-release/olive.main'
 
 jobs:
-  docker:
+  Build:
     runs-on: ubuntu-latest
     steps:
       - name: Get current time
@@ -20,11 +20,13 @@ jobs:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
           path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
-          repository-name: ${{ vars.BUILD_MAIN_REPOSITORY_NAME }}
-          image-name: ${{ vars.BUILD_MAIN_IMAGE_NAME }}
+          organization-name: ${{ vars.BUILD_ORGANIZATION_NAME }}
+          repository-name: ${{ vars.BUILD_REPOSITORY_NAME }}
           image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-${{ steps.current-time.outputs.formattedTime }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
-          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-sources: '("git+https://github.com/Pearson-Advance/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
           tutor-plugin-names: '("ecommerce" "discovery" "mfe")'
+          tutor-pearson-plugin-url: ${{ vars.TUTOR_PEARSON_PLUGIN_URL }}
+          tutor-pearson-plugin-name: 'pearson-plugin-ecommerce-prod'

--- a/.github/workflows/build-push-image-main.yml
+++ b/.github/workflows/build-push-image-main.yml
@@ -26,6 +26,7 @@ jobs:
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
+          gh-access-token: ${{ secrets.GH_PAT }}
           tutor-plugin-sources: '("git+https://github.com/Pearson-Advance/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
           tutor-plugin-names: '("ecommerce" "discovery" "mfe")'
           tutor-pearson-plugin-url: ${{ vars.TUTOR_PEARSON_PLUGIN_URL }}

--- a/.github/workflows/build-push-image-stage.yml
+++ b/.github/workflows/build-push-image-stage.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           format: YYYY-MM-DD-HH-mm
       - name: Build Image
-        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        uses: Pearson-Advance/tutor-build-image-action@v1.0.0
         with:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}

--- a/.github/workflows/build-push-image-stage.yml
+++ b/.github/workflows/build-push-image-stage.yml
@@ -6,7 +6,7 @@ on:
       - 'pearson-release/olive.stage'
 
 jobs:
-  docker:
+  Build:
     runs-on: ubuntu-latest
     steps:
       - name: Get current time
@@ -20,11 +20,13 @@ jobs:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
           path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
-          repository-name: ${{ vars.BUILD_STAGE_REPOSITORY_NAME }}
-          image-name: ${{ vars.BUILD_STAGE_IMAGE_NAME }}
+          organization-name: ${{ vars.BUILD_ORGANIZATION_NAME }}
+          repository-name: ${{ vars.BUILD_REPOSITORY_NAME }}
           image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-RC-${{ steps.current-time.outputs.formattedTime }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
-          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-sources: '("git+https://github.com/Pearson-Advance/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
           tutor-plugin-names: '("ecommerce" "discovery" "mfe")'
+          tutor-pearson-plugin-url: ${{ vars.TUTOR_PEARSON_PLUGIN_URL }}
+          tutor-pearson-plugin-name: 'pearson-plugin-ecommerce-stg'

--- a/.github/workflows/build-push-image-stage.yml
+++ b/.github/workflows/build-push-image-stage.yml
@@ -1,0 +1,30 @@
+name: Tutor Build Action Test
+
+on:
+  push:
+    branches:
+      - 'pearson-release/olive.stage'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current time
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DD-HH-mm
+      - name: Build Image
+        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        with:
+          python-version: ${{ vars.BUILD_PYTHON_VERSION }}
+          tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
+          path-image-to-be-built: 'env/plugins/ecommerce/build/ecommerce'
+          repository-name: ${{ vars.BUILD_STAGE_REPOSITORY_NAME }}
+          image-name: ${{ vars.BUILD_STAGE_IMAGE_NAME }}
+          image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-RC-${{ steps.current-time.outputs.formattedTime }}
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
+          tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
+          tutor-plugin-names: '("ecommerce" "discovery" "mfe")'

--- a/.github/workflows/build-push-image-stage.yml
+++ b/.github/workflows/build-push-image-stage.yml
@@ -25,6 +25,7 @@ jobs:
           image-tag: ${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}-RC-${{ steps.current-time.outputs.formattedTime }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          gh-access-token: ${{ secrets.GH_PAT }}
           use-docker-cache: ${{ vars.BUILD_USE_CACHE }}
           tutor-plugin-sources: '("git+https://github.com/Pearson-Advance/tutor-ecommerce.git@v${{ vars.ECOMMERCE_TUTOR_PLUGIN_VERSION }}" "git+https://github.com/overhangio/tutor-mfe.git@v15.0.5" "git+https://github.com/overhangio/tutor-discovery.git@v15.0.0")'
           tutor-plugin-names: '("ecommerce" "discovery" "mfe")'


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-377

## Description

This PR changes composite action version due to [tutor-build-image-action](https://github.com/Pearson-Advance/tutor-build-image-action) created a new tag (**v1.0.0**).

## Type of Change

- [x] Change composite version in workflow for production.
- [x] Change composite version in workflow for stage.

## How to test

- Create a test PR in the ecommerce repository.
- Merge this PR into the target branch.
- Check that the Github Action is triggered by the PR merge event.
- Check the output of the image build creation for any issues or silent issues.
-  When the process is complete, check the Docker Hub Pearson repository and verify that the image has been built (https://hub.docker.com/repository/docker/paops/edxapp/general).
-  Use the image in a local environment to test it out.

## Reviewers

- [ ] @Squirrel18
- [ ] @alexjmpb 
