### PR TITLE
fix: use name in case course data is cached.

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -275,7 +275,7 @@ class BasketLogicMixin:
                 course_data['image_url'] = course.get('media', {}).get('image', {}).get('raw', '')
 
             course_data['product_description'] = course.get('short_description', '')
-            course_data['product_title'] = course.get('title', '')
+            course_data['product_title'] = course.get('title', '') or course.get('name', '')
             course_data['product_subject'] = course.get('subjects') and course.get('subjects')[0].get('slug')
 
             # The course start/end dates are not currently used


### PR DESCRIPTION
# Description:

Checkout page is not showing the course title as shown here:

![image](https://github.com/Pearson-Advance/ecommerce/assets/40271196/e9bd4883-7fb1-4bfa-aa9b-d0295e9c6e67)

Discovery is doing its job since all data is available at https://discovery-pc.pearson.com/api/v1/course_runs/course-v1:VUE+10001+2023/ . However, when course data is cached the `title` is persisted as `name`, therefore the title is empty.

**Notes:**

- Rebooting the redis cluster had no effect.
- Don't know how title is renamed to name. I just checked it by going to basket page https://payments-certprep.pearson.com/basket/add/?sku=D961D19  and checking the basket programatically.

```
from oscar.core.loading import get_model
from opaque_keys.edx.keys import CourseKey
from ecommerce.core.utils import get_cache_key
from edx_django_utils.cache import TieredCache



Basket = get_model('basket', 'Basket')
line = Basket.objects.filter(owner__username='studiooo').all_lines()[0]
product = line.product
resource = "course_runs"
cache_key = get_cache_key(site_domain=''payments-certprep.pearson.com', resource="{}-{}".format(resource, CourseKey.from_string(product.attr.course_key)))
course_cached_response = TieredCache.get_cached_response(cache_key)


course_cached_response.value.get('name') # There is no title key.
```

# Changes

- [ ] Get `name` when `title` is not available

# How to test it?

Given a course already added to e-commerce as professional only. Go to https://ecomm-url/basket/add/?sku=course-sku

Checkout page should include de title.