### PR TITLE
feat: Fixing enterprise offer page

### DIFF
--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -2,7 +2,7 @@
 
     <% if (courses.length > 1) { %>
         <div class="offer-page-heading">
-            <h3 class="heading"><%= pageHeading %></h3>
+            <h3 class="heading">Welcome</h3>
             <p><%= pageHeadingMessage %></p>
         </div>
     <% } %>
@@ -22,15 +22,8 @@
                 <div class="box-shadow col-xs-12">
                     <div class="col-sm-5">
                         <div class="image-container">
-                            <div class="discount-percentage"><p><%= course.attributes.benefit_value %>
-                                <span><%- gettext('off') %></span></p>
-                            </div>
                             <img class="img-responsive" src="<%= course.attributes.image_url %>"
                                  alt="<%= course.attributes.title %>"/>
-
-                            <div class="voucher-valid-until">
-                                <p><%= course.attributes.voucher_end_date_text %></p>
-                            </div>
                         </div>
                     </div>
                     <div class="col-sm-7 col-xs-12">
@@ -43,24 +36,8 @@
                         <p class="course-start"><%= course.attributes.course_start_date_text %></p>
 
                         <div class="discount-mc-price-group clearfix">
-                            <% if (course.attributes.multiple_credit_providers) { %>
                             <div class="pull-left">
-                                <p class="course-new-price">
-                                    <span><%= course.attributes.benefit_value %> <%- gettext('discount') %></span>
-                                </p>
                             </div>
-                            <% } else { %>
-                            <div class="pull-left">
-                                <p class="course-price">
-                                    <span>$<%= course.attributes.stockrecords.price_excl_tax %></span>
-                                </p>
-                            </div>
-                            <div class="pull-left">
-                                <p class="course-new-price">
-                                    <span><%- gettext('Now') %> $<%= course.attributes.new_price %></span>
-                                </p>
-                            </div>
-                            <% } %>
                             <div class="pull-right">
                                     <% if (isCredit) { %>
                                         <a href="/credit/checkout/<%= course.attributes.id %>/?code=<%= code %>"
@@ -69,14 +46,16 @@
                                            data-track-type="click"
                                            data-track-event="edx.bi.ecommerce.coupons.accept_offer"
                                            data-track-category="coupon-codes"
-                                           data-course-id="<%= course.attributes.id %>">
+                                           data-course-id="<%= course.attributes.id %>"
+                                           style="margin-bottom: 10px;">
                                             <%- gettext('Get Credit') %>
                                         </a>
                                     <% } else { %>
                                         <% if (isEnrollmentCode) { %>
                                         <a href="/coupons/redeem/?code=<%= code %>&sku=<%= course.attributes.stockrecords.partner_sku %>"
                                            id="RedeemEnrollment"
-                                           class="btn btn-success"><%- gettext('Enroll Now') %></a>
+                                           class="btn btn-success"
+                                           style="margin-bottom: 10px;"><%- gettext('Enroll Now') %></a>
                                         <% } else { %>
                                             <a href="/coupons/redeem/?code=<%= code %>&sku=<%= course.attributes.stockrecords.partner_sku %>"
                                                id="PurchaseCertificate"
@@ -84,7 +63,8 @@
                                                data-track-type="click"
                                                data-track-event="edx.bi.ecommerce.coupons.accept_offer"
                                                data-track-category="coupon-codes"
-                                               data-course-id="<%= course.attributes.id %>">
+                                               data-course-id="<%= course.attributes.id %>"
+                                               style="margin-bottom: 10px;">
                                                 <%- gettext('Checkout') %>
                                             </a>
                                         <% } %>

--- a/ecommerce/templates/coupons/offer.html
+++ b/ecommerce/templates/coupons/offer.html
@@ -14,27 +14,6 @@
             <div class="row">
                 <div id="offerApp" data-offer-app-page-heading="{{ offer_app_page_heading }}" data-offer-app-page-heading-message="{{ offer_app_page_heading_message }}">
                 </div>
-                <section class="verified-info col-xs-12 col-md-4 col-lg-12 hidden">
-                    <p class="earn-verified-certificate col-xs-12 col-lg-5 pull-left-lg">{% trans "Earn a verified certificate in one of our popular courses to advance your career, showcase your accomplishments or enhance your college application." as tmsg %}{{ tmsg | force_escape }}</p>
-
-                    <div class="verified-certificate-info clearfix">
-                        <h3 class="verified-certificate-info-header col-xs-12 col-sm-7 col-md-12 col-lg-4 pull-right-lg pull-right-sm">
-                            {% trans "Why buy a verified certificate?" as tmsg %}{{ tmsg | force_escape }}</h3>
-
-                        <div class="col-xs-12 col-sm-5 col-md-12 col-lg-3 pull-left-lg pull-left-sm">
-                            <img class="img-responsive"
-                                 src="{% static "images/example-certificate-verified.png" %}"
-                                 alt="{% trans "A verified certificate (digital) confirming that a user has completed the course on a specified date. The certificate includes edX's logo and the university's logo, as well as signatures from faculty members involved with the course. There is also a URL that can be used to verify the authenticity of the certificate." as tmsg %}{{ tmsg | force_escape }}"/>
-                        </div>
-                        <div class="col-xs-12 col-sm-7 col-md-12 col-lg-4 pull-right-lg">
-                            <p>{% trans "A verified certificate demonstrates to future employers that you've mastered the course material." as tmsg %}{{ tmsg | force_escape }}</p>
-
-                            <p>{% trans "The certificate is officially signed and stamped by the institution that offers the course." as tmsg %}{{ tmsg | force_escape }}</p>
-
-                            <p>{% trans "You're twelve times more likely to complete the course if you're working toward a verified certificate." as tmsg %}{{ tmsg | force_escape }}</p>
-                        </div>
-                    </div>
-                </section>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-784

## Description

This PR changes the coupons offer page to remove edX branding and discount references

## Type of Change

- [x] Modify _offer_course_list template
- [x] Modify offer template

## How to test

- Configure enterprise
- Configure comprehensive theming in ecommerce
- Create an enterprise coupon
- Select one of the themes
- The /coupons/offer/?code=<coupon> page should look like the screenshots

## Screenshots

![Screenshot from 2023-10-24 17-56-22](https://github.com/Pearson-Advance/ecommerce/assets/62396424/70185f15-8063-4f95-9b35-d7bfec81e2bb)
![Screenshot from 2023-10-24 17-56-03](https://github.com/Pearson-Advance/ecommerce/assets/62396424/9cd608e3-127f-40a4-b795-0cc57f2c04ae)


## Reviewers

- [ ] @Squirrel18
- [ ] @Serafin-dev  
