### PR TITLE
PADV 832 - Enterprise - remove the start date and org from the course card

### DIFF
--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -338,7 +338,8 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         elif 'card_image_url' in course_info:
             image = course_info['card_image_url']
         else:
-            image = ''
+            # Get the course image from the LMS course API format.
+            image = course_info.get('media', {}).get('image', {}).get('raw', '')
         return {
             'benefit': serializers.BenefitSerializer(benefit).data,
             'contains_verified': is_verified,

--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -31,10 +31,6 @@
                             <p><%= course.attributes.title %></p>
                         </div>
 
-                        <p class="course-org"><%= course.attributes.organization %></p>
-
-                        <p class="course-start"><%= course.attributes.course_start_date_text %></p>
-
                         <div class="discount-mc-price-group clearfix">
                             <div class="pull-left">
                             </div>


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-832

## Description

This PR aims to remove the start date and org from the enterprise offer page and add a fix to show the image of the course correctly in the same page.

## Type of Change

- [x] Modify _offer_course_list template
- [x] Modify image retrieving

## How to test

- Configure enterprise
- Configure comprehensive theming in ecommerce
- Create an enterprise coupon
- Select one of the themes
- The /coupons/offer/?code=<coupon> page should look like the screenshots

## Screenshots
![Screenshot from 2023-11-01 11-44-11](https://github.com/Pearson-Advance/ecommerce/assets/62396424/7c185bda-fc67-4118-9468-8a0cf93a1aa2)


## Reviewers

- [ ] @anfbermudezme 
- [ ] @Jacatove   
