### PR TITLE
Fix obtain course images from LMS.

### DIFF
--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -4,11 +4,9 @@ from urllib.parse import unquote, urljoin
 
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
+from ecommerce.core.utils import deprecated_traverse_pagination, get_cache_key
 from edx_django_utils.cache import TieredCache
 from opaque_keys.edx.keys import CourseKey
-
-from ecommerce.core.utils import deprecated_traverse_pagination, get_cache_key
-
 
 LMS_COURSES_API_BASE_URL = '/api/courses/v1/courses/'
 

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -339,7 +339,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             image = course_info['card_image_url']
         else:
             # Get the course image from the LMS course API format.
-            image = course_info.get('media', {}).get('image', {}).get('raw', '')
+            image = course_info.get('image_url', '')
         return {
             'benefit': serializers.BenefitSerializer(benefit).data,
             'contains_verified': is_verified,


### PR DESCRIPTION
# Description

This PR fix the way to obtain images from the LMS in vouchers.

# Changes made

- [x] obtain image using image_url from LMS.

![image](https://github.com/Pearson-Advance/ecommerce/assets/30726391/2fad574b-1b74-4dff-8338-57e916ec5d0e)
