### PR TITLE
PADV-1034 -Modify redeem Enterprise coupon page.

### DIFF
--- a/ecommerce/static/js/collections/offer_collection.js
+++ b/ecommerce/static/js/collections/offer_collection.js
@@ -14,7 +14,7 @@ define([
 
             initialize: function() {
                 this.page = 1;
-                this.perPage = 6;
+                this.perPage = 10;
                 this.populated = false;
                 this.updateLimits();
                 this.on('update', this.updateNumberOfPages);

--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -3,6 +3,7 @@
     <% if (courses.length > 1) { %>
         <div class="offer-page-heading">
             <h3 class="heading">Welcome</h3>
+            <h4>Please choose a relevant course from the options below.</h4>
             <p><%= pageHeadingMessage %></p>
         </div>
     <% } %>

--- a/ecommerce/templates/coupons/offer.html
+++ b/ecommerce/templates/coupons/offer.html
@@ -12,7 +12,7 @@
     <div id="offer">
         <div class="container">
             <div class="row">
-                <div id="offerApp" data-offer-app-page-heading="{{ offer_app_page_heading }}" data-offer-app-page-heading-message="{{ offer_app_page_heading_message }}">
+                <div id="offerApp">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Description:

This PR changes the redeem Enterprise coupon page per client requirements:

- Increase the number of courses to be displayed to 10.
- Change the introductory language.
- Remove unnecessary text.

## Screenshots:
### Before:
![image](https://github.com/Pearson-Advance/ecommerce/assets/17520199/9781e967-c5bd-4696-84ec-d5a687de7773)
### After:
![image](https://github.com/Pearson-Advance/ecommerce/assets/17520199/b6b90f8f-8604-4ab0-a354-ebaadb41ca0f)

## How to test?
- Configure enterprise: https://open-edx-enterprise-service-documentation.readthedocs.io/en/latest/getting_started.html
- Set up an Enterprise customer.
- Set up an Enterprise catalogue.
- Configure Discovery service and run the metadata refresh command: https://edx-discovery.readthedocs.io/en/latest/quickstart.html
- Create an enterprise coupon and assign a catalogue to it: ECOMMERCE-HOST/enterprise/coupons
- Compile static files: make static (inside the ecommerce shell)
- Go to the redeem coupon page: ECOMMERCE-HOST/coupons/offer/?code=Enterprise coupon code
- Check that the changes have been applied.

## Note:
These changes have been added here because .js files cannot be overwritten using themes and these changes apply to all sites.

## Reviewers:
- [ ] @alexjmpb 