### PR TITLE
PADV-3088 BE - Add coupon_code parameter to MFE redirect URL

### DIFF
--- a/ecommerce/enterprise_coupons/utils.py
+++ b/ecommerce/enterprise_coupons/utils.py
@@ -1,19 +1,23 @@
 """
 Helper methods for enterprise app.
 """
+from urllib.parse import urlencode, urljoin
+
 from django.conf import settings
 
 
-def get_build_mfe_base_url(catalog_uuid, base_url):
+def get_build_mfe_base_url(catalog_uuid, base_url, coupon_code):
     """
-    Build the base URL for the ecommerce microfrontend receipt page with catalog parameter.
+    Build the base URL for the ecommerce microfrontend receipt page with catalog and coupon parameters.
 
     Args:
         catalog_uuid (UUID): The catalog UUID to include in the microfrontend URL.
         base_url (str): The base URL of the LMS instance.
+        coupon_code (str): The coupon code to include in the microfrontend URL.
 
     Returns:
-        str: The complete URL for the ecommerce microfrontend receipt page with the catalog parameter appended.
+        str: The complete URL for the ecommerce microfrontend receipt page with the catalog
+             and coupon_code parameters appended.
 
     Raises:
         ValueError: If ENTERPRISE_COUPONS_MFE_URL is not configured in settings.
@@ -22,4 +26,4 @@ def get_build_mfe_base_url(catalog_uuid, base_url):
     if not mfe_path:
         raise ValueError('ENTERPRISE_COUPONS_MFE_URL is not configured in settings.')
 
-    return f'{base_url}{mfe_path}?catalog={catalog_uuid}'
+    return f"{urljoin(base_url, mfe_path)}?{urlencode({'catalog': catalog_uuid, 'coupon_code': coupon_code})}"

--- a/ecommerce/enterprise_coupons/views.py
+++ b/ecommerce/enterprise_coupons/views.py
@@ -39,7 +39,7 @@ class CouponRedirectView(View):
         try:
             catalog_uuid = get_enterprise_catalog_uuid_from_coupon(coupon_code)
             base_url = request.site.siteconfiguration.lms_url_root
-            mfe_url = get_build_mfe_base_url(catalog_uuid, base_url)
+            mfe_url = get_build_mfe_base_url(catalog_uuid, base_url, coupon_code)
             return redirect(mfe_url)
         except CouponNotFoundError as e:
             logger.error('Coupon not found: %s - Error: %s', coupon_code, str(e))


### PR DESCRIPTION
## Description
This PR updates the E-commerce redirection logic to include the coupon_code as a query parameter when redirecting users to the Micro-Frontend (MFE).

Currently, the /enterprise-coupons/<coupon_code>/ endpoint only passes the catalog_uuid. However, the Discovery MFE requires the coupon_code to correctly build enrollment URLs within the EnterpriseCatalogCourseSerializer. By passing this parameter, we ensure the EnterpriseCatalogQueryParamsSerializer in Discovery receives the necessary data to process enterprise enrollments successfully.

### Type of Change
Modify get_build_mfe_base_url utility to support the coupon_code parameter.

Update CouponRedirectView to pass the extracted coupon code to the MFE URL generator.

Enhance redirect URL structure: ?catalog={uuid}&coupon_code={code}.

## How to Test
### Prerequisites
Ensure the E-commerce service is running.

Verify that ENTERPRISE_COUPONS_MFE_URL is configured in your settings.

Have a valid Catalog UUID and a Coupon Code ready for testing.

Testing Steps
Trigger the Redirection: Access the redirection endpoint using a valid coupon code in your browser or via curl:

GET /coupon-view/{coupon_code}/
Verify the Redirect URL: Check that the resulting redirection URL follows this format: https://<mfe-url>/?catalog=<catalog_uuid>&coupon_code=<coupon_code>


Validate Parameter Capture: Ensure that the coupon_code value in the URL matches the one used in the initial request.

## Reviewers

- [ ] @Squirrel18 