### PR TITLE
PADV-2899 BE Redirect current coupons/offer/?code requests to the new endpoint.

### DIFF
--- a/ecommerce/enterprise_coupons/utils.py
+++ b/ecommerce/enterprise_coupons/utils.py
@@ -6,13 +6,12 @@ from urllib.parse import urlencode, urljoin
 from django.conf import settings
 
 
-def get_build_mfe_base_url(catalog_uuid, base_url, coupon_code):
+def get_build_mfe_base_url(catalog_uuid, coupon_code):
     """
     Build the base URL for the ecommerce microfrontend receipt page with catalog and coupon parameters.
 
     Args:
         catalog_uuid (UUID): The catalog UUID to include in the microfrontend URL.
-        base_url (str): The base URL of the LMS instance.
         coupon_code (str): The coupon code to include in the microfrontend URL.
 
     Returns:
@@ -26,4 +25,4 @@ def get_build_mfe_base_url(catalog_uuid, base_url, coupon_code):
     if not mfe_path:
         raise ValueError('ENTERPRISE_COUPONS_MFE_URL is not configured in settings.')
 
-    return f"{urljoin(base_url, mfe_path)}?{urlencode({'catalog': catalog_uuid, 'coupon_code': coupon_code})}"
+    return f"{mfe_path}?{urlencode({'catalog': catalog_uuid, 'coupon_code': coupon_code})}"

--- a/ecommerce/enterprise_coupons/views.py
+++ b/ecommerce/enterprise_coupons/views.py
@@ -38,8 +38,7 @@ class CouponRedirectView(View):
     def get(self, request, coupon_code):
         try:
             catalog_uuid = get_enterprise_catalog_uuid_from_coupon(coupon_code)
-            base_url = request.site.siteconfiguration.lms_url_root
-            mfe_url = get_build_mfe_base_url(catalog_uuid, base_url, coupon_code)
+            mfe_url = get_build_mfe_base_url(catalog_uuid, coupon_code)
             return redirect(mfe_url)
         except CouponNotFoundError as e:
             logger.error('Coupon not found: %s - Error: %s', coupon_code, str(e))


### PR DESCRIPTION
## Description
This PR fixes the E-commerce redirection logic in CouponRedirectView to correctly build the MFE redirect URL.

Previously, get_build_mfe_base_url was receiving lms_url_root as a base_url parameter and prepending it to ENTERPRISE_COUPONS_MFE_URL. Since ENTERPRISE_COUPONS_MFE_URL is already an absolute URL, this caused a malformed redirect (e.g. http://lms.example.com/http://mfe.example.com?catalog=<uuid>).

This PR removes the base_url parameter so the redirect uses the MFE URL directly from settings.

Note: The ENTERPRISE_COUPONS_MFE_URL setting and the corresponding Caddy configuration still need to be added to the tutor-pearson-plugin repository for this to work in deployed environments.

### Type of Change
Remove base_url parameter from get_build_mfe_base_url utility.
Update CouponRedirectView to call get_build_mfe_base_url without lms_url_root.
### How to Test
#### Prerequisites
E-commerce service is running.
ENTERPRISE_COUPONS_MFE_URL is configured in your settings (e.g. http://localhost:2006).
A valid coupon code is available.
#### Testing Steps
Access the redirect endpoint:

GET /enterprise-coupons/<coupon_code>/
Verify the redirect URL follows this format:

http://<mfe-url>?catalog=<catalog_uuid>
Confirm the URL does not include the LMS host prepended to the MFE URL.

## Reviewers

- [ ] @Squirrel18 